### PR TITLE
Extend ski format to indicate if the planet is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,23 @@
 
 1. Colorized error output.
 
-2. Added --no-color flag to disable the colorized output.
+2. Added column to ski format to indicate if the planet is valid:
 
-3. Print errors without line breaks if not pretty printed.
+   ```
+   $ ff -f=ski valid-package invalid-package
+   1|valid-package|server|App Package|user@hostname-1.de
+   0|valid-package|server|App Package|missing user
+   ```
 
-4. Log errors if referenced server is unknown or invalid.
+3. Added --no-color flag to disable the colorized output.
 
-5. Return result set in sorted order.
+4. Print errors without line breaks if not pretty printed.
 
-6. Exit with failure if type is missing.
+5. Log errors if referenced server is unknown or invalid.
+
+6. Return result set in sorted order.
+
+7. Exit with failure if type is missing.
 
 ### 1.4.0 (10.03.2017)
 
@@ -34,9 +42,9 @@
 
    ```
    $ fifa -p -c type=server "type:db|web"
-  +-----+------------+--------+-----------+-------------+------------------------+-------+
+   +-----+------------+--------+-----------+-------------+------------------------+-------+
    |                          ./fifa -p -c type=server type:db|web                        |
-  +-----+------------+--------+-----------+-------------+------------------------+-------+
+   +-----+------------+--------+-----------+-------------+------------------------+-------+
    | NR. | ID         | TYPE   | NAME      | MATCHER     | CONNECTION             | COUNT |
    +-----+------------+--------+-----------+-------------+------------------------+-------+
    |  0. | my-app     | server | Server    | type=server | user1@url1.de          | 1     |

--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ Get the connection by type:
     $ export ORBIT_FILE=/path/to/orbit.json
 
     $ fifa app-package-1 app-package-2
-    $ user@hostname-1.de
-    $ user@hostname-2.de
+    user@hostname-1.de
+    user@hostname-2.de
 
     $ fifa -f=tns db-package
-    $ (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=host.de)(PORT=1234)))(CONNECT_DATA=(SID=hostid)))
+    (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=host.de)(PORT=1234)))(CONNECT_DATA=(SID=hostid)))
 
 Passing ids is optional. If no ids are specified, then _ff_ executes the request for all found planets.
 
 Get the type:
 
     $ fifa -t db-package
-    $ db
+    db
 
 Get a specific attribute:
 
     $ fifa -a=port db-package
-    $ 12343
+    12343
 
 Get count of matching planets:
 
@@ -129,10 +129,11 @@ Lets find all productive server Jens has to take care about:
 
 Format used by the _ski_ tool:
 
-    $ fifa --no-colors -f=ski app-package db-package web-package
-    $ app-package|server|My App-Package|user1@url1.de
-    $ db-package|db|My DB-Package|OP-DB:user1@url1.de
-    $ web-package|web|My Web-Package|https://url.1.net
+    $ fifa --no-colors -f=ski
+    1|app-package|server|My App-Package|user1@url1.de
+    0|other-package|server|Other Package|missing user
+    1|db-package|db|My DB-Package|OP-DB:user1@url1.de
+    1|web-package|web|My Web-Package|https://url.1.net
 
 The general format is `type|id|name|type specific connection`.
 

--- a/bintest/fifa.rb
+++ b/bintest/fifa.rb
@@ -214,9 +214,16 @@ assert('ski format') do
   output, status = Open3.capture2(ORBIT_ENV, BINARY, '-f=ski')
 
   assert_true status.success?, 'Process did not exit cleanly'
-  assert_include output, 'my-app|server|Server|user1@url1.de'
-  assert_include output, 'my-db|db|Database|OP_DB:user1@url1.de'
-  assert_include output, 'my-web|web|Webserver|https://url.1.net'
+  assert_include output, '1|my-app|server|Server|user1@url1.de'
+  assert_include output, '1|my-db|db|Database|OP_DB:user1@url1.de'
+  assert_include output, '1|my-web|web|Webserver|https://url.1.net'
+
+  output, status = Open3.capture2(INCMP_ENV, BINARY, '-f=ski')
+
+  assert_false status.success?, 'Process did exit cleanly'
+  assert_include output, '0|my-app|server||'
+  assert_include output, '0|my-db|db||'
+  assert_include output, '0|my-web|web||'
 end
 
 assert('pretty type') do

--- a/mrblib/ff/formatter/base.rb
+++ b/mrblib/ff/formatter/base.rb
@@ -29,7 +29,7 @@ module FF
       # or the format is not supported!
       #
       # @param [ Symbol ] format The name of the format.
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def format(format, params)
@@ -41,7 +41,7 @@ module FF
       # Connection formatted to use for CURL.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def url(params)
@@ -54,18 +54,34 @@ module FF
       # Connection formatted to use for internals.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
-      def ski(params)
-        "#{params['id']}|#{params['type']}|#{params['name']}|#{default(params)}"
+      def ski(p)
+        id     = p['id']
+        value  = ski_value(p)
+        bit    = logger.errors?(id) ? 0 : 1
+        format = "#{bit}|#{id}|#{p['type']}|#{p['name']}|#{value}"
+
+        log(id, format, !parser.print_pretty?) unless bit == 1
+
+        format
       end
 
       private
 
+      # The content for the ski format.
+      #
+      # @param [ Hash ] params JSON decoded planet.
+      #
+      # @return [ String ]
+      def ski_value(params)
+        default(params)
+      end
+
       # Raises an error if a provided attribute is missing.
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       # @param [ Array<String> ] keys The names of the params to check for.
       #
       # @return [ Void ]

--- a/mrblib/ff/formatter/database.rb
+++ b/mrblib/ff/formatter/database.rb
@@ -27,7 +27,7 @@ module FF
       # Connection formatted to use for JDBC driver.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def jdbc(params)
@@ -46,7 +46,7 @@ module FF
       # Connection formatted to use with SqlPlus
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def sqlplus(params)
@@ -64,7 +64,7 @@ module FF
       # Connection formatted to use for TNS listener.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def tns(params)
@@ -75,7 +75,7 @@ module FF
       # Connection formatted to use for qpdb.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def pqdb(params)
@@ -83,21 +83,13 @@ module FF
         "#{params['db']}:#{find_planet(params).connection(:ssh)}"
       end
 
-      # Connection formatted to use for internals.
-      # Raises an error if a required attribute is missing!
-      #
-      # @param [ Array<String> ] params List of attributes where to look for.
-      #
-      # @return [ String ]
-      def ski(params)
-        "#{params['id']}|db|#{params['name']}|#{pqdb(params)}"
-      end
-
       private
+
+      alias ski_value pqdb
 
       # The references planet
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ FF::Planet ]
       def find_planet(params)

--- a/mrblib/ff/formatter/server.rb
+++ b/mrblib/ff/formatter/server.rb
@@ -27,7 +27,7 @@ module FF
       # Connection formatted to use for SSH.
       # Raises an error if a required attribute is missing!
       #
-      # @param [ Array<String> ] params List of attributes where to look for.
+      # @param [ Hash ] params JSON decoded planet.
       #
       # @return [ String ]
       def ssh(params)

--- a/mrblib/ff/logger.rb
+++ b/mrblib/ff/logger.rb
@@ -37,15 +37,20 @@ module FF
     #
     # @param [ Object ] key Usually the planet id.
     # @param [ String ] msg The error message.
+    # @param [ Boolean ] replace Remove all previously logged messages.
     #
-    # @return [ Void ]
-    def add(key, msg)
+    # @return [ String ]
+    def add(key, msg, replace = false)
       bucket = (@errors[key] ||= [])
+
+      bucket.clear if replace
 
       if msg.is_a? String
         bucket << msg
+        msg
       else
-        bucket.concat msg
+        bucket.concat(msg)
+        msg.first
       end
     end
 


### PR DESCRIPTION
## About
If a planet was invalid for any reason, _fifa_ responded only with the error messages like "missing user".

By doing so any other tool lost information about the associated planet.

    $ ff -f=ski
    package-1|server|App Package|user@hostname-1.de
    missing user

## Changes
Added a column as the head to indicate if the planet is valid (__1__) or invalid (__0__). The other columns of invalid entries are filled by content as well as able. The pretty printed output additionally contains all errors.

    $ ff -f=ski
    1|package-1|server|App Package 1|user@hostname.de
    0|package-2|server|App Package 2|missing user

## Implementation
The trick is to log the ski output of an invalid planet as an error.
https://github.com/appPlant/ff/blob/feature/extended_ski_format/mrblib/ff/formatter/base.rb#L66